### PR TITLE
Fix implementation not matching interface

### DIFF
--- a/src/ezgzip.mli
+++ b/src/ezgzip.mli
@@ -1,3 +1,5 @@
+open Rresult
+
 (** {1 gzip compression} *)
 
 (** Possible error cases *)


### PR DESCRIPTION
This fixes an error I'm getting when compiling this package under NixOS.

I'm not sure why this is not triggered otherwise, but it could be because of the order of the `-I` flags?

```
File "src/ezgzip.ml", line 1:
Error: The implementation src/ezgzip.ml
       does not match the interface src/.ezgzip.objs/byte/ezgzip.cmi:
       Values do not match:
         val decompress :
           ?ignore_size:bool ->
           ?ignore_checksum:bool ->
           ?max_size:int ->
           string -> (string, [> `Gzip of error ]) Rresult.result
       is not included in
         val decompress :
           ?ignore_size:bool ->
           ?ignore_checksum:bool ->
           ?max_size:int -> string -> (string, [> `Gzip of error ]) result
       File "src/ezgzip.mli", lines 24-26, characters 0-40:
         Expected declaration
       File "src/ezgzip.ml", line 214, characters 4-14: Actual declaration
```